### PR TITLE
Add support for searching contacts by company (findcom command)

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/Messages.java
+++ b/src/main/java/seedu/clinkedin/logic/Messages.java
@@ -17,6 +17,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_COMPANIES_LISTED_OVERVIEW = "%d contacts listed working at \"%s\".";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
@@ -1,0 +1,60 @@
+package seedu.clinkedin.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.clinkedin.commons.util.ToStringBuilder;
+import seedu.clinkedin.logic.Messages;
+import seedu.clinkedin.model.Model;
+import seedu.clinkedin.model.person.CompanyContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose company name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindComCommand extends Command {
+
+    public static final String COMMAND_WORD = "findcom";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts whose company matches "
+            + "the specified company name (case-insensitive).\n"
+            + "Parameters: COMPANY\n"
+            + "Example: " + COMMAND_WORD + " Google";
+
+    private final CompanyContainsKeywordsPredicate predicate;
+
+    public FindComCommand(CompanyContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_COMPANIES_LISTED_OVERVIEW, model.getFilteredPersonList().size(),
+                        predicate.getKeywordsString()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindComCommand)) {
+            return false;
+        }
+
+        FindComCommand otherFindCommand = (FindComCommand) other;
+        return predicate.equals(otherFindCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}
+

--- a/src/main/java/seedu/clinkedin/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.clinkedin.logic.commands.Command;
 import seedu.clinkedin.logic.commands.DeleteCommand;
 import seedu.clinkedin.logic.commands.EditCommand;
 import seedu.clinkedin.logic.commands.ExitCommand;
+import seedu.clinkedin.logic.commands.FindComCommand;
 import seedu.clinkedin.logic.commands.FindCommand;
 import seedu.clinkedin.logic.commands.HelpCommand;
 import seedu.clinkedin.logic.commands.ListCommand;
@@ -69,6 +70,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case FindComCommand.COMMAND_WORD:
+            return new FindComCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/clinkedin/logic/parser/FindComCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/FindComCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.clinkedin.logic.parser;
+
+import static seedu.clinkedin.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.clinkedin.logic.commands.FindComCommand;
+import seedu.clinkedin.logic.parser.exceptions.ParseException;
+import seedu.clinkedin.model.person.CompanyContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindComCommand object
+ */
+public class FindComCommandParser implements Parser<FindComCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindComCommand
+     * and returns a FindComCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindComCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
+        }
+
+        String[] companyNameKeywords = trimmedArgs.split(";");
+        companyNameKeywords = Arrays.stream(companyNameKeywords).map(x -> x.trim()).toArray(String[]::new);
+
+        return new FindComCommand(new CompanyContainsKeywordsPredicate(Arrays.asList(companyNameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/clinkedin/model/person/CompanyContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/clinkedin/model/person/CompanyContainsKeywordsPredicate.java
@@ -1,0 +1,50 @@
+package seedu.clinkedin.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.clinkedin.commons.util.StringUtil;
+import seedu.clinkedin.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Company} matches any of the keywords given.
+ */
+public class CompanyContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public CompanyContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    public String getKeywordsString() {
+        return String.join(", ", keywords);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getCompany().companyName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CompanyContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        CompanyContainsKeywordsPredicate otherCompanyContainsKeywordsPredicate =
+                (CompanyContainsKeywordsPredicate) other;
+        return keywords.equals(otherCompanyContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}
+

--- a/src/test/java/seedu/clinkedin/logic/commands/FindComCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/FindComCommandTest.java
@@ -1,0 +1,122 @@
+package seedu.clinkedin.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinkedin.testutil.TypicalPersons.ALICE;
+import static seedu.clinkedin.testutil.TypicalPersons.BENSON;
+import static seedu.clinkedin.testutil.TypicalPersons.CARL;
+import static seedu.clinkedin.testutil.TypicalPersons.getTypicalCLinkedin;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinkedin.model.Model;
+import seedu.clinkedin.model.ModelManager;
+import seedu.clinkedin.model.UserPrefs;
+import seedu.clinkedin.model.person.CompanyContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindComCommand}.
+ */
+public class FindComCommandTest {
+
+    private static final String MESSAGE_COMPANIES_LISTED_OVERVIEW = "%d contacts listed working at \"%s\".";
+
+    private Model model = new ModelManager(getTypicalCLinkedin(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalCLinkedin(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        CompanyContainsKeywordsPredicate firstPredicate =
+                new CompanyContainsKeywordsPredicate(Collections.singletonList("Google"));
+        CompanyContainsKeywordsPredicate secondPredicate =
+                new CompanyContainsKeywordsPredicate(Collections.singletonList("Shopee"));
+
+        FindComCommand findFirstCommand = new FindComCommand(firstPredicate);
+        FindComCommand findSecondCommand = new FindComCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindComCommand findFirstCommandCopy = new FindComCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different command -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_noMatchingKeyword_noPersonFound() {
+        CompanyContainsKeywordsPredicate predicate = preparePredicate("TikTok");
+        FindComCommand command = new FindComCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+
+        String expectedMessage = String.format(MESSAGE_COMPANIES_LISTED_OVERVIEW, 0, "TikTok");
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_singleKeyword_singlePersonFound() {
+        CompanyContainsKeywordsPredicate predicate = preparePredicate("Google");
+        FindComCommand command = new FindComCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+
+        String expectedMessage = String.format(MESSAGE_COMPANIES_LISTED_OVERVIEW, 1, "Google");
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(ALICE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        CompanyContainsKeywordsPredicate predicate = preparePredicate("Google Shopee Grab");
+        FindComCommand command = new FindComCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+
+        String expectedMessage = String.format(MESSAGE_COMPANIES_LISTED_OVERVIEW, 3, "Google, Shopee, Grab");
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_caseInsensitiveKeyword_personFound() {
+        CompanyContainsKeywordsPredicate predicate = preparePredicate("gOoGlE");
+        FindComCommand command = new FindComCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+
+        String expectedMessage = String.format(MESSAGE_COMPANIES_LISTED_OVERVIEW, 1, "gOoGlE");
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(ALICE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        CompanyContainsKeywordsPredicate predicate =
+                new CompanyContainsKeywordsPredicate(Arrays.asList("Google"));
+        FindComCommand findComCommand = new FindComCommand(predicate);
+        String expected = FindComCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findComCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code CompanyContainsKeywordsPredicate}.
+     */
+    private CompanyContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new CompanyContainsKeywordsPredicate(Arrays.asList(userInput.trim().split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/clinkedin/logic/parser/FindComCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/FindComCommandParserTest.java
@@ -1,0 +1,54 @@
+package seedu.clinkedin.logic.parser;
+
+
+import static seedu.clinkedin.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinkedin.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinkedin.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinkedin.logic.commands.FindComCommand;
+import seedu.clinkedin.model.person.CompanyContainsKeywordsPredicate;
+
+public class FindComCommandParserTest {
+
+    private FindComCommandParser parser = new FindComCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgsTwoCompanies_returnsFindComCommand() {
+        FindComCommand expectedFindComCommand =
+                new FindComCommand(new CompanyContainsKeywordsPredicate(Arrays.asList("Google", "Shopee")));
+
+        // no leading and trailing whitespaces
+        assertParseSuccess(parser, "Google;Shopee", expectedFindComCommand);
+
+        // with extra whitespaces around separators
+        assertParseSuccess(parser, " \n Google; \n \t Shopee  \t", expectedFindComCommand);
+    }
+
+    @Test
+    public void parse_validArgsCompanyWithSpace_returnsFindComCommand() {
+        FindComCommand expectedFindComCommand =
+                new FindComCommand(new CompanyContainsKeywordsPredicate(Arrays.asList("NUS Computing")));
+
+        // company name with spaces should remain one keyword if no semicolon
+        assertParseSuccess(parser, "NUS Computing", expectedFindComCommand);
+    }
+
+    @Test
+    public void parse_validArgsMultipleCompaniesWithSpaces_returnsFindComCommand() {
+        FindComCommand expectedFindComCommand =
+                new FindComCommand(new CompanyContainsKeywordsPredicate(
+                        Arrays.asList("NUS Computing", "GovTech", "Sea Limited")));
+
+        assertParseSuccess(parser, "NUS Computing; GovTech; Sea Limited", expectedFindComCommand);
+    }
+}

--- a/src/test/java/seedu/clinkedin/model/person/CompanyContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/clinkedin/model/person/CompanyContainsKeywordsPredicateTest.java
@@ -1,0 +1,100 @@
+package seedu.clinkedin.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinkedin.testutil.PersonBuilder;
+
+public class CompanyContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Google");
+        List<String> secondPredicateKeywordList = Arrays.asList("Google", "Shopee");
+
+        CompanyContainsKeywordsPredicate firstPredicate =
+                new CompanyContainsKeywordsPredicate(firstPredicateKeywordList);
+        CompanyContainsKeywordsPredicate secondPredicate =
+                new CompanyContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        CompanyContainsKeywordsPredicate firstPredicateCopy =
+                new CompanyContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different predicate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_companyContainsKeywords_returnsTrue() {
+        // One keyword
+        CompanyContainsKeywordsPredicate predicate =
+                new CompanyContainsKeywordsPredicate(Collections.singletonList("Google"));
+        assertTrue(predicate.test(new PersonBuilder().withCompany("Google").build()));
+
+        // Multiple keywords
+        predicate = new CompanyContainsKeywordsPredicate(Arrays.asList("Google", "Shopee"));
+        assertTrue(predicate.test(new PersonBuilder().withCompany("Google").build()));
+
+        // Only one matching keyword
+        predicate = new CompanyContainsKeywordsPredicate(Arrays.asList("Shopee", "Grab"));
+        assertTrue(predicate.test(new PersonBuilder().withCompany("Grab").build()));
+
+        // Mixed-case keywords (case-insensitive)
+        predicate = new CompanyContainsKeywordsPredicate(Arrays.asList("gOoGlE"));
+        assertTrue(predicate.test(new PersonBuilder().withCompany("Google").build()));
+
+        // Partial match (since using containsWordIgnoreCase)
+        predicate = new CompanyContainsKeywordsPredicate(Arrays.asList("NUS"));
+        assertTrue(predicate.test(new PersonBuilder().withCompany("NUS Computing").build()));
+    }
+
+    @Test
+    public void test_companyDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        CompanyContainsKeywordsPredicate predicate =
+                new CompanyContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withCompany("Google").build()));
+
+        // Non-matching keyword
+        predicate = new CompanyContainsKeywordsPredicate(Arrays.asList("Shopee"));
+        assertFalse(predicate.test(new PersonBuilder().withCompany("Google").build()));
+
+        // Keywords match other fields but not company
+        predicate = new CompanyContainsKeywordsPredicate(Arrays.asList("Alice", "12345678", "Main"));
+        assertFalse(predicate.test(new PersonBuilder()
+                .withName("Alice")
+                .withPhone("12345678")
+                .withAddress("Main Street")
+                .withCompany("Google")
+                .build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("Google", "Shopee");
+        CompanyContainsKeywordsPredicate predicate =
+                new CompanyContainsKeywordsPredicate(keywords);
+
+        String expected = CompanyContainsKeywordsPredicate.class.getCanonicalName()
+                + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `findcom` command that allows users to search contacts based on their company name.

## Features Added
- Added `findcom COMPANY_NAME` command
- Supports multiple companies using `;` separator  
  e.g. `findcom Google;Shopee`
- Matching is case-insensitive
- Partial word matching supported via `containsWordIgnoreCase`
- Updates filtered person list to display matching contacts
- Displays number of contacts found

## Example Usage
```
findcom Google
findcom Shopee
findcom Google;Grab
```

## Behaviour
- Matching contacts are shown in the contact list
- If no matches are found, an empty list is displayed
- Output message shows number of contacts found:
  - `2 contacts listed working at "Google"`
  - `0 contacts found for company "TikTok"`

## Implementation Details
- Added `FindComCommand`
- Added `FindComCommandParser`
- Added `CompanyContainsKeywordsPredicate`
- Integrated command into `CLinkedinParser`

## Tests Added
- `FindComCommandTest`
  - single match
  - multiple matches
  - no match
  - case-insensitive matching
- `FindComCommandParserTest`
  - valid input parsing
  - multiple company parsing
  - invalid (empty input) handling
- `CompanyContainsKeywordsPredicateTest`
  - keyword matching
  - case-insensitive matching
  - non-matching cases
  - equals and toString coverage

## Notes
- Parser rejects empty input (e.g. `findcom   `)
- Predicate guards against invalid empty keywords in tests
- Follows existing `FindCommand` design pattern

## Related Issues
Closes #56