### PR TITLE
Update restore success message to include missing tag message

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/RestoreCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/RestoreCommand.java
@@ -26,6 +26,8 @@ public class RestoreCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_RESTORE_PERSON_SUCCESS = "Restored Person: %1$s";
+    public static final String MESSAGE_RESTORE_MISSING_TAGS =
+            "Note: Some tags could not be restored as they were renamed and/or deleted.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
     public static final String MESSAGE_DUPLICATE_PHONE = "Duplicate phone number detected";
 
@@ -55,8 +57,17 @@ public class RestoreCommand extends Command {
         }
 
         Person cleanedPerson = model.restorePerson(recordToRestore);
-        return new CommandResult(String.format(MESSAGE_RESTORE_PERSON_SUCCESS,
-                Messages.format(cleanedPerson)));
+
+        int deletedRecordTagCount = recordToRestore.getPerson().getTags().size();
+        int restoredTagCount = cleanedPerson.getTags().size();
+
+        String message = String.format(MESSAGE_RESTORE_PERSON_SUCCESS, Messages.format(cleanedPerson));
+
+        if (restoredTagCount < deletedRecordTagCount) {
+            message += "\n" + MESSAGE_RESTORE_MISSING_TAGS;
+        }
+
+        return new CommandResult(message);
     }
 
     @Override

--- a/src/test/java/seedu/clinkedin/logic/commands/RestoreCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/RestoreCommandTest.java
@@ -51,6 +51,28 @@ public class RestoreCommandTest {
     }
 
     @Test
+    public void execute_restoreWithMissingTags_showsWarningMessage() {
+        // Remove tag so it is missing during restore
+        model.deleteTag(new Tag("friends"));
+
+        RestoreCommand restoreCommand = new RestoreCommand(Index.fromZeroBased(0));
+
+        Person expectedRestoredPerson = new PersonBuilder(ALICE)
+                .withTags()
+                .build();
+
+        String expectedMessage = String.format(RestoreCommand.MESSAGE_RESTORE_PERSON_SUCCESS,
+                Messages.format(expectedRestoredPerson))
+                + "\n" + RestoreCommand.MESSAGE_RESTORE_MISSING_TAGS;
+
+        Model expectedModel = new ModelManager(new CLinkedin(model.getCLinkedin()), new UserPrefs());
+        DeletedPersonRecord recordToRestore = expectedModel.getFilteredDeletedPersonRecordList().get(0);
+        expectedModel.restorePerson(recordToRestore);
+
+        assertCommandSuccess(restoreCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredDeletedPersonRecordList().size() + 1);
         RestoreCommand restoreCommand = new RestoreCommand(outOfBoundIndex);


### PR DESCRIPTION
if the tag is renamed/deleted after a contact is deleted.
"Note: Some tags could not be restored as they were renamed and/or deleted." will be shown after restoring the contact.

close [Bug] Tag delete - Renamed tags handling in Deleted list #132 

