### PR TITLE
Add error message for space in Tag Rename

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/tag/TagRenameCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/tag/TagRenameCommand.java
@@ -27,6 +27,7 @@ public class TagRenameCommand extends TagCommand {
             + "Example: tag " + COMMAND_WORD + " friends colleagues";
     public static final String MESSAGE_TAG_NOT_FOUND = "Old tag not found.";
     public static final String MESSAGE_DUPLICATE_TAG = "Tag name already exists.";
+    public static final String MESSAGE_SPACE_IN_TAG = "Tag names cannot contain spaces.\n%1$s";
 
     private final Tag oldTag;
     private final Tag newTag;

--- a/src/main/java/seedu/clinkedin/logic/parser/tag/TagRenameCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/tag/TagRenameCommandParser.java
@@ -18,7 +18,12 @@ public class TagRenameCommandParser implements Parser<TagRenameCommand> {
         String trimmedArgs = args.trim();
         String[] tags = trimmedArgs.split("\\s+");
 
-        if (tags.length != 2) {
+        if (tags.length > 2) {
+            throw new ParseException(
+                    String.format(TagRenameCommand.MESSAGE_SPACE_IN_TAG, TagRenameCommand.MESSAGE_USAGE));
+        }
+
+        if (tags.length < 2) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagRenameCommand.MESSAGE_USAGE));
         }

--- a/src/test/java/seedu/clinkedin/logic/parser/tag/TagRenameCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/tag/TagRenameCommandParserTest.java
@@ -27,6 +27,11 @@ public class TagRenameCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagRenameCommand.MESSAGE_USAGE);
         assertParseFailure(parser, "friends", expectedMessage);
         assertParseFailure(parser, " ", expectedMessage);
-        assertParseFailure(parser, "friends colleagues family", expectedMessage);
+    }
+
+    @Test
+    public void parse_tagNameWithSpaces_throwsParseException() {
+        String expectedMessage = String.format(TagRenameCommand.MESSAGE_SPACE_IN_TAG, TagRenameCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "friends close friends", expectedMessage);
     }
 }


### PR DESCRIPTION
## **Description**

The `tag rename` command does not support tag names containing spaces. When user attempt to rename a tag to a multi-word name, it will now return an error message indicating that spaces are not allowed in tag names: `Tag names cannot contain spaces`

---

### Implementation
After splitting the parameter string by space, it will return the new error message if more than 2 words are found.