### PR TITLE
Fix non case-sensitive tag bug

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/tag/TagAssignCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/tag/TagAssignCommand.java
@@ -54,7 +54,7 @@ public class TagAssignCommand extends TagCommand {
      */
     private Tag getExistingTag(Model model, Tag tag) {
         for (Tag t : model.getCLinkedin().getTagList()) {
-            if (t.tagName.equalsIgnoreCase(tag.tagName)) {
+            if (t.tagName.equals(tag.tagName)) {
                 return t;
             }
         }


### PR DESCRIPTION
Closes #111 , #112 

Changed the `getExistingTags()` method to check for the tags (preserving case-sensitive and tag colour)