### PR TITLE
Update find error message

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/FindCommand.java
@@ -17,8 +17,8 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: KEYWORD [;MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alice; bob; charlie";
 
     private final NameContainsKeywordsPredicate predicate;
 


### PR DESCRIPTION
Fixes #134 

```
Parameters: KEYWORD [;MORE_KEYWORDS]...
Example: find alice; bob; charlie
```

UG has already been updated before:
```
Format: `find KEYWORD [;MORE_KEYWORDS]`

* The search is case-insensitive. e.g `hans` will match `Hans`
* The order of the keywords matter. e.g. `Hans Bo` will not match `Bo Hans`
* Only the name is searched.
* Partial words will be matched e.g. `Han` will match `Hans`
* Contacts containing the entire keyword will be returned (i.e. `.contains()` search).
  e.g. `Hans Bo` will return `Hans Bobber`, but not `Hans Lim`

Examples:
* `find John` returns `john` and `John Doe`
* `find alex david` returns `Alex David` only
* `find alex; yu` returns `Alex Yeoh` and `Bernice Yu`
```