### PR TITLE
Add brightness check

### DIFF
--- a/src/main/java/seedu/clinkedin/ui/TagUtil.java
+++ b/src/main/java/seedu/clinkedin/ui/TagUtil.java
@@ -14,6 +14,9 @@ public class TagUtil {
     public static Label tagLabel(String tagName, String tagColor) {
         Label tag = new Label(tagName);
         String color = String.format("-fx-background-color: %s;", tagColorToHexString(tagColor));
+        if (colorIsTooBright(tagColor)) {
+            color += "-fx-text-fill: black;";
+        }
         tag.setStyle(color);
         return tag;
     }
@@ -35,5 +38,17 @@ public class TagUtil {
                         + format(value.getBlue())
                         + format(value.getOpacity()))
                 .toUpperCase();
+    }
+
+    /**
+     * Returns a brightness value
+     */
+    public static boolean colorIsTooBright(String color) {
+        double brightness = Color.web(color).getBrightness();
+        double threshold = 0.7;
+        if (brightness >= threshold) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/seedu/clinkedin/ui/TagUtilTest.java
+++ b/src/test/java/seedu/clinkedin/ui/TagUtilTest.java
@@ -11,4 +11,16 @@ public class TagUtilTest {
         String blueHex = TagUtil.tagColorToHexString("blue");
         assertEquals("#0000FFFF", blueHex);
     }
+
+    @Test
+    public void tagUtil_yellowColorTooBright_isTrue() {
+        boolean isTooBright = TagUtil.colorIsTooBright("yellow");
+        assertEquals(true, isTooBright);
+    }
+
+    @Test
+    public void tagUtil_blackColorTooBright_isFalse() {
+        boolean isTooBright = TagUtil.colorIsTooBright("black");
+        assertEquals(false, isTooBright);
+    }
 }


### PR DESCRIPTION
Fixes #143 

Luckily JavaFX color has a `.getBrightness` to determine a color's brightness, I've set the current threshold at `0.7` and it seems to work pretty well.

codecov last 2 missing lines will be skipped because i can't test javafx ui components in the testcase without doing magic