### PR TITLE
Fix tag formatting

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/Messages.java
+++ b/src/main/java/seedu/clinkedin/logic/Messages.java
@@ -1,5 +1,6 @@
 package seedu.clinkedin.logic;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,8 +60,11 @@ public class Messages {
             builder.append("; Link: ")
                     .append(person.getLink());
         }
-        builder.append("; Tags: ");
-        person.getTags().forEach(builder::append);
+        if (!person.getTags().isEmpty()) {
+            builder.append("; Tags: ");
+            List<String> tagList = person.getTags().stream().map(x -> x.toString()).collect(Collectors.toList());
+            builder.append(String.join(", ", tagList));
+        }
         return builder.toString();
     }
 

--- a/src/main/java/seedu/clinkedin/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/AddCommand.java
@@ -11,6 +11,7 @@ import static seedu.clinkedin.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.clinkedin.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -85,7 +86,8 @@ public class AddCommand extends Command {
         }
 
         if (!nonExistentTags.isEmpty()) {
-            throw new CommandException(MESSAGE_TAGS_DO_NOT_EXIST + nonExistentTags.toString());
+            List<String> tagList = nonExistentTags.stream().map(x -> x.toString()).collect(Collectors.toList());
+            throw new CommandException(MESSAGE_TAGS_DO_NOT_EXIST + String.join(", ", tagList));
         }
 
         Person toAddWithExistingTags = getPersonWithTags(toAdd, model);

--- a/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -73,7 +74,8 @@ public class AddCommandTest {
         Person invalidTagsPerson = new PersonBuilder().withTags("Ferrari", "Mercedes").build();
         AddCommand addCommand = new AddCommand(invalidTagsPerson);
         ModelStubWithPersonFriendsTag modelStub = new ModelStubWithPersonFriendsTag(invalidTagsPerson);
-        String errorMessage = AddCommand.MESSAGE_TAGS_DO_NOT_EXIST + invalidTagsPerson.getTags();
+        List<String> tagList = invalidTagsPerson.getTags().stream().map(x -> x.toString()).collect(Collectors.toList());
+        String errorMessage = AddCommand.MESSAGE_TAGS_DO_NOT_EXIST + String.join(", ", tagList);
 
         assertThrows(CommandException.class, errorMessage, () -> addCommand.execute(modelStub));
     }


### PR DESCRIPTION
tags format is now `[tag1], [tag2]`
and tags won't appear if it's not in the `add`/`edit` command

118
Issue 1: Empty tag display
<img width="737" height="152" alt="image" src="https://github.com/user-attachments/assets/d8e6242a-5d57-4cd0-895f-53edde860e7d" />

Issue 2: Multiple tags formatting
<img width="979" height="63" alt="image" src="https://github.com/user-attachments/assets/54c09f2f-fe82-4787-9a65-c616d30a264c" />

Issue 3: Invalid tag error message formatting
<img width="490" height="55" alt="image" src="https://github.com/user-attachments/assets/68ca234f-c882-4dfc-aa43-21ea43b89d46" />

122
Issue 1: Editing contact with no tags
<img width="713" height="107" alt="image" src="https://github.com/user-attachments/assets/281b10f2-b552-4f2d-9fc7-cf4eda0a90a6" />

Issue 2: Removing all tags from a contact
output:
`Edited Person: name; Phone: 87438807; Email: alexyeoh@example.com; Address: Blk 30 Geylang Street 29, #06-40; Company Name: Google; Remark: Enjoys AI and basketball; Link: https://www.linkedin.com/in/alexyeoh`

Fixes #118, Fixes #122 