### PR TITLE
Fix deleted time display to be updated

### DIFF
--- a/src/main/java/seedu/clinkedin/ui/PersonCard.java
+++ b/src/main/java/seedu/clinkedin/ui/PersonCard.java
@@ -27,6 +27,7 @@ public class PersonCard extends UiPart<Region> {
     private static final Logger logger = LogsCenter.getLogger(PersonCard.class);
 
     public final Person person;
+    private LocalDateTime deletedDateTimeValue;
 
     @FXML
     private HBox cardPane;
@@ -100,10 +101,16 @@ public class PersonCard extends UiPart<Region> {
      */
     public PersonCard(DeletedPersonRecord deletedPersonRecord, int displayedIndex) {
         this(deletedPersonRecord.getPerson(), displayedIndex);
-
-        deletedDateTime.setText(formatDeletedDateTime(deletedPersonRecord.getDeletedDateTime()));
+        this.deletedDateTimeValue = deletedPersonRecord.getDeletedDateTime();
+        refreshDeletedDateTime();
         deletedDateTime.setVisible(true);
         deletedDateTime.setManaged(true);
+    }
+
+    private void refreshDeletedDateTime() {
+        if (deletedDateTimeValue != null) {
+            deletedDateTime.setText(formatDeletedDateTime(deletedDateTimeValue));
+        }
     }
 
     //@@author


### PR DESCRIPTION
Fixes stale deleted-contact relative timestamp display when reopening the deleted list.

Previously, the `X minutes ago` text was only computed when the deleted `PersonCard` was first created, so the displayed time could become outdated after switching away from and reopening the deleted view.

This PR updates the deleted-contact timestamp display so it refreshes based on the current time whenever the deleted list is shown again.

Example:
- delete a contact
- wait 1 minute
- run `deleted` → shows `Deleted: 1 minute ago`
- switch away with `list`
- wait 2 more minutes
- run `deleted` again → now shows `Deleted: 3 minutes ago`

To close #266 