### PR TITLE
Fix deleted list panel display

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/DeletedCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/DeletedCommand.java
@@ -30,7 +30,7 @@ public class DeletedCommand extends Command {
         model.updateFilteredDeletedPersonRecordList(PREDICATE_SHOW_ALL_DELETED_PERSON_RECORDS);
 
         if (model.getFilteredDeletedPersonRecordList().isEmpty()) {
-            return new CommandResult(MESSAGE_NO_DELETED_RECORDS);
+            return new CommandResult(MESSAGE_NO_DELETED_RECORDS, false, true, false);
         }
 
         return new CommandResult(MESSAGE_SUCCESS, false, true, false);


### PR DESCRIPTION
Fixes the `deleted` command so it always shows the deleted-contact list, even when there are no deleted records.

Previously, when there were no deleted contacts, running `deleted` only showed a message indicating that there were 0 deleted records, while the previously displayed active-contact list remained on screen. This made the UI state unclear and misleading.

This PR updates the command/UI flow so the app now switches to the deleted-contact view consistently. When there are no deleted contacts, an empty deleted list is shown instead, making the app state clearer for users.

this close #242 