### PR TITLE
Fix UG and message inconsistencies for `add`, `find`/`findcom`, and `sortcom`

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -171,15 +171,15 @@ The following sequence diagram illustrates how the `findcom` command is handled 
 
 #### Sorting contacts by company
 
-The `sortcom` command allows users to sort the currently displayed non-deleted contact list alphabetically by company name.
+The `sortcom` command allows users to sort the active contact list alphabetically by company name.
 
 <box type="info" seamless>
 
-**Note:** The sorting operation is applied only to the **filtered non-deleted contact list** (i.e., the currently displayed non-deleted contacts), not the entire dataset.
+**Note:** The sorting operation is applied only to the **active contact list** (i.e., the currently displayed non-deleted contacts), not the entire dataset.
 
 </box>
 
-When the command is executed, the system sorts the filtered non-deleted contact list by company name in a case-insensitive manner. Contacts without a company are treated as having an empty value and will appear at the top of the displayed list. If multiple contacts have the same company value, their names are used as a secondary sorting key, followed by phone number to keep the ordering deterministic. The sorted list is then shown to the user together with a success message.
+When the command is executed, the system sorts the active contact list by company name in a case-insensitive manner. Contacts without a company are treated as having an empty value and will appear at the top of the displayed list. If multiple contacts have the same company value, their names are used as a secondary sorting key to keep the ordering deterministic. The sorted list is then shown to the user together with a success message.
 
 The following activity diagram illustrates the flow of the `sortcom` command:
 
@@ -621,13 +621,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Guarantees:**
 
-* If successful, the currently displayed non-deleted contact list is sorted by company name.
+* If successful, the active contact list is sorted by company name.
 * If unsuccessful, the non-deleted contact list remains unchanged.
 
 #### **MSS**
 
 1. User requests to sort contacts by entering the `sortcom` command.
-2. CLinkedin sorts the currently displayed non-deleted contact list by company name (case-insensitive), with name and phone number used as tie-breakers when needed.
+2. CLinkedin sorts the active contact list by company name (case-insensitive), with name and phone number used as tie-breakers when needed.
 3. CLinkedin displays the sorted non-deleted contact list.
 4. CLinkedin displays a success message.
 
@@ -751,12 +751,12 @@ testers are expected to do more *exploratory* testing.
        Expected: No contacts are shown. Error details shown in the status message.
 
 ### Sorting contact list by company name
-- Sorting non-deleted contacts by company name alphabetically
+- Sorting active contacts by company name alphabetically
 
-    1. Prerequisites: Multiple non-deleted contacts in the list with company names.
+    1. Prerequisites: Multiple active contacts in the list with company names.
 
     1. Test case: `sortcom`<br>
-       Expected: Non-deleted contacts are shown in alphabetical order by company name. Success message shown.
+       Expected: Active contacts are shown in alphabetical order by company name. Success message shown.
 
 ### Viewing recently deleted contacts
 - Viewing deleted contacts

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -175,7 +175,7 @@ The `sortcom` command allows users to sort the active contact list alphabeticall
 
 <box type="info" seamless>
 
-**Note:** The sorting operation is applied only to the **active contact list** (i.e., the currently displayed non-deleted contacts), not the entire dataset.
+**Note:** `sortcom` applies only to the **active contact list**. If the active contact list is currently filtered, the sorting is applied to the filtered active list instead. `sortcom` does not apply to the deleted list.
 
 </box>
 
@@ -622,13 +622,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Guarantees:**
 
 * If successful, the active contact list is sorted by company name.
-* If unsuccessful, the non-deleted contact list remains unchanged.
+* If unsuccessful, the active contact list remains unchanged.
 
 #### **MSS**
 
 1. User requests to sort contacts by entering the `sortcom` command.
 2. CLinkedin sorts the active contact list by company name (case-insensitive), with name and phone number used as tie-breakers when needed.
-3. CLinkedin displays the sorted non-deleted contact list.
+3. CLinkedin displays the sorted active contact list.
 4. CLinkedin displays a success message.
 
    Use case ends.
@@ -665,7 +665,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **Tag**: A short label used to categorise contacts (e.g., recruiter, fintech).
 * **Company**: The organisation or company that a contact is associated with.
 * **Remark**: Additional notes or comments about a contact.
-* **Filtered non-deleted contact list**: The subset of non-deleted contacts currently displayed after applying a command.
 * **Duplicate contact**: Two contacts with the same phone number.
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -171,15 +171,15 @@ The following sequence diagram illustrates how the `findcom` command is handled 
 
 #### Sorting contacts by company
 
-The `sortcom` command allows users to sort the currently displayed contact list alphabetically by company name.
+The `sortcom` command allows users to sort the currently displayed non-deleted contact list alphabetically by company name.
 
 <box type="info" seamless>
 
-**Note:** The sorting operation is applied only to the **filtered contact list** (i.e., the currently displayed contacts), not the entire dataset.
+**Note:** The sorting operation is applied only to the **filtered non-deleted contact list** (i.e., the currently displayed non-deleted contacts), not the entire dataset.
 
 </box>
 
-When the command is executed, the system sorts the filtered contact list by company name in a case-insensitive manner. Contacts without a company are treated as having an empty value and will appear at the top of the displayed list. The sorted list is then shown to the user together with a success message.
+When the command is executed, the system sorts the filtered non-deleted contact list by company name in a case-insensitive manner. Contacts without a company are treated as having an empty value and will appear at the top of the displayed list. If multiple contacts have the same company value, their names are used as a secondary sorting key, followed by phone number to keep the ordering deterministic. The sorted list is then shown to the user together with a success message.
 
 The following activity diagram illustrates the flow of the `sortcom` command:
 
@@ -621,14 +621,14 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Guarantees:**
 
-* If successful, the currently displayed contact list is sorted by company name.
-* If unsuccessful, the contact list remains unchanged.
+* If successful, the currently displayed non-deleted contact list is sorted by company name.
+* If unsuccessful, the non-deleted contact list remains unchanged.
 
 #### **MSS**
 
 1. User requests to sort contacts by entering the `sortcom` command.
-2. CLinkedin sorts the currently displayed contact list alphabetically by company name (case-insensitive).
-3. CLinkedin displays the sorted contact list.
+2. CLinkedin sorts the currently displayed non-deleted contact list by company name (case-insensitive), with name and phone number used as tie-breakers when needed.
+3. CLinkedin displays the sorted non-deleted contact list.
 4. CLinkedin displays a success message.
 
    Use case ends.
@@ -665,7 +665,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **Tag**: A short label used to categorise contacts (e.g., recruiter, fintech).
 * **Company**: The organisation or company that a contact is associated with.
 * **Remark**: Additional notes or comments about a contact.
-* **Filtered contact list**: The subset of contacts currently displayed after applying a command.
+* **Filtered non-deleted contact list**: The subset of non-deleted contacts currently displayed after applying a command.
 * **Duplicate contact**: Two contacts with the same phone number.
 
 --------------------------------------------------------------------------------------------------------------------
@@ -751,12 +751,12 @@ testers are expected to do more *exploratory* testing.
        Expected: No contacts are shown. Error details shown in the status message.
 
 ### Sorting contact list by company name
-- Sorting contacts by company name alphabetically
+- Sorting non-deleted contacts by company name alphabetically
 
-    1. Prerequisites: Multiple contacts in the list with company names.
+    1. Prerequisites: Multiple non-deleted contacts in the list with company names.
 
     1. Test case: `sortcom`<br>
-       Expected: Contacts are shown in alphabetical order by company name. Success message shown.
+       Expected: Non-deleted contacts are shown in alphabetical order by company name. Success message shown.
 
 ### Viewing recently deleted contacts
 - Viewing deleted contacts
@@ -895,3 +895,5 @@ We reused AB3’s core architecture (commands, parser, model), which reduced set
 ## **Appendix: Planned Enhancements**
 These enhancements are planned for future iterations:
 - Improve tag restoration behaviour: when restoring a deleted contact, tags that were renamed will be correctly mapped to their updated names instead of being removed.
+- Support more flexible phone number formats: The current implementation accepts only digit-only phone numbers of 8 to 15 digits. Future versions may support formats with spaces, country codes, and symbols such as `+`, `(`, `)`, and `-`.
+- Extend sortcom support to the deleted-contact list: Currently, sortcom only sorts the active non-deleted contact list. In a future version, we may support sorting the deleted-contact list when it is being displayed as well.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -300,26 +300,26 @@ Examples:
 
 #### 3. Sorting contacts by company: `sortcom`
 
-Sorts the currently displayed non-deleted contact list alphabetically by company name.
+Sorts the active contact list alphabetically by company name.
 
 Format:
 `sortcom`
 
 * Sorting is **case-insensitive**.
   e.g. `apple`, `Apple`, `APPLE` are treated the same.
-* Only the **currently displayed non-deleted contact list** is sorted (e.g. after `findcom` or `tag show`).
+* Only the **active contact list** is sorted (e.g. after `findcom` or `tag show`).
 * Contacts without a company are treated as having an empty value and will appear at the **top of the list**. 
-* If multiple contacts have no company or the same company, they are further sorted by **name**, followed by **phone number**.
+* If multiple contacts have no company or the same company, they are further sorted by **name**.
 * The sorting does **not permanently change** the original order of contacts.
 
 Examples:
 
 * `sortcom`
-  Sorts all currently displayed non-deleted contacts by company name in alphabetical order.
+  Sorts all active contacts by company name in alphabetical order.
 
   * `findcom Google`
     `sortcom`
-    First filters non-deleted contacts by company "Google", then sorts the filtered results alphabetically.
+    First filters active contacts by company "Google", then sorts the filtered results alphabetically.
 
 ---
 
@@ -456,7 +456,7 @@ Furthermore, certain edits can cause CLinkedin to behave in unexpected ways (e.g
 **A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous CLinkedin home folder.
 
 **Q**: Why does `sortcom` not sort all contacts after using `tag show`?<br>
-**A**: `sortcom` sorts only the **currently displayed non-deleted contact list**. After `tag show`, the list is filtered, so only that subset is sorted. Use `list` first to sort all contacts.
+**A**: `sortcom` sorts only the **active (currently displayed non-deleted) contact list**. After `tag show`, the list is filtered, so only that subset is sorted. Use `list` first to sort all contacts.
 
 **Q**: Why are tag changes (rename, delete, color) not reflected in the deleted list?<br>
 **A**: The deleted list stores a **snapshot** of the contact at the time it was deleted. Changes made to tags afterward (e.g., renaming, deletion, or color updates) will not affect this snapshot.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -121,15 +121,32 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/COMPANY] [l/LINK] [r/REM
 
 **Input constraints:**
 - **Name**
-    - Contains only letters, spaces, apostrophes (`'`) and hyphens (`-`)
+  - Contains only letters, spaces, apostrophes (`'`) and hyphens (`-`)
+  - Must not start or end with spaces
+  - Must not contain multiple consecutive spaces
+  - Maximum 100 characters
+- **Phone Number**
+  - Must contain digits only 
+  - Must be between 8 and 15 digits long
+- **Email Address**
+  - Must be in the format `local-part@domain` 
+  - Must contain exactly one `@` and no spaces 
+  - Must not contain consecutive dots 
+  - The local part may contain letters, numbers, and `+`, `_`, `.`, `-`, but must start and end with an alphanumeric character
+  - The domain must contain at least one `.`
+  - Each domain label must start and end with an alphanumeric character 
+  - Domain labels may contain only letters, numbers, and hyphens (`-`)
+  - The last domain label must be at least 2 characters long
+- **Address**
+    - Must not contain `/` or `@`
+    - Must not start or end with spaces
+    - Must not contain multiple consecutive spaces
     - Maximum 100 characters
 - **Company**
     - Contains only letters, numbers, spaces, `. , & -`
-    - Maximum 50 characters
-- **Address**
-    - Must not contain `/` or `@`
+    - Must not start or end with spaces
     - Must not contain multiple consecutive spaces
-    - Maximum 100 characters
+    - Maximum 50 characters
 - **Link**
     - Must start with `http://` or `https://`
     - Must not contain spaces in the link
@@ -250,6 +267,7 @@ Format: `find KEYWORD [;MORE_KEYWORDS]`
 * Partial words will be matched e.g. `Han` will match `Hans`
 * Contacts containing the entire keyword will be returned (i.e. `.contains()` search).
   e.g. `Hans Bo` will return `Hans Bobber`, but not `Hans Lim`
+* Empty keywords are not allowed.
 
 Examples:
 * `find John` returns `john` and `John Doe`
@@ -267,6 +285,7 @@ Format:
   e.g. `google`, `Google`, `GOOGLE` are treated the same.
 * A contact will be shown if its company contains **any of the given keywords**.
 * Multiple keywords can be provided by separating them with `;`.
+* Empty keywords are not allowed.
 
 Examples:
 
@@ -281,25 +300,26 @@ Examples:
 
 #### 3. Sorting contacts by company: `sortcom`
 
-Sorts the currently displayed contact list alphabetically by company name.
+Sorts the currently displayed non-deleted contact list alphabetically by company name.
 
 Format:
 `sortcom`
 
 * Sorting is **case-insensitive**.
   e.g. `apple`, `Apple`, `APPLE` are treated the same.
-* Only the **currently displayed list** is sorted (e.g. after `findcom` or `tag show`).
-* Contacts without a company are treated as having an empty value and will appear at the **top of the list**.
+* Only the **currently displayed non-deleted contact list** is sorted (e.g. after `findcom` or `tag show`).
+* Contacts without a company are treated as having an empty value and will appear at the **top of the list**. 
+* If multiple contacts have no company or the same company, they are further sorted by **name**, followed by **phone number**.
 * The sorting does **not permanently change** the original order of contacts.
 
 Examples:
 
 * `sortcom`
-  Sorts all currently displayed contacts by company name in alphabetical order.
+  Sorts all currently displayed non-deleted contacts by company name in alphabetical order.
 
   * `findcom Google`
     `sortcom`
-    First filters contacts by company "Google", then sorts the filtered results alphabetically.
+    First filters non-deleted contacts by company "Google", then sorts the filtered results alphabetically.
 
 ---
 
@@ -436,7 +456,7 @@ Furthermore, certain edits can cause CLinkedin to behave in unexpected ways (e.g
 **A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous CLinkedin home folder.
 
 **Q**: Why does `sortcom` not sort all contacts after using `tag show`?<br>
-**A**: `sortcom` sorts only the **currently displayed contact list**. After `tag show`, the list is filtered, so only that subset is sorted. Use `list` first to sort all contacts.
+**A**: `sortcom` sorts only the **currently displayed non-deleted contact list**. After `tag show`, the list is filtered, so only that subset is sorted. Use `list` first to sort all contacts.
 
 **Q**: Why are tag changes (rename, delete, color) not reflected in the deleted list?<br>
 **A**: The deleted list stores a **snapshot** of the contact at the time it was deleted. Changes made to tags afterward (e.g., renaming, deletion, or color updates) will not affect this snapshot.

--- a/src/main/java/seedu/clinkedin/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/AddCommand.java
@@ -30,7 +30,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a contact to CLinkedin. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "


### PR DESCRIPTION
**PR Description:**
This PR updates documentation and messages to better match the current implementation, and adds planned enhancements for limitations not addressed in this version.

Changes made:
* Added a planned enhancement for overzealous phone number validation blocking valid real-world input formats.
* Updated the `add` command error message to align with the UG wording by referring to adding a contact to CLinkedin instead of a person to the address book.
* Updated UG input constraints to include missing details for:

  * Company: only single spaces are allowed between words, and the value cannot start or end with spaces
  * Phone Number: added relevant missing constraints
  * Email: added relevant missing constraints
* Updated `sortcom` documentation to clarify that it only sorts the currently displayed non-deleted contact list.
* Updated `sortcom` documentation to state that name and phone number are used as tie-breakers when needed.
* Added a planned enhancement for extending `sortcom` support to the deleted-contact list.

Issues closed:
* closes #263 
* closes #256 
* closes #254 
* closes #237 
* closes #219 