### PR TITLE
Clarify sortcom scope, align find/findcom keyword validation, and stabilize sort order for empty companies

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -469,8 +469,8 @@ Action              | Format, Examples
 **Clear**           | `clear`
 **Delete**          | `delete INDEX`<br> e.g., `delete 3`
 **Edit**            | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [c/COMPANY] [l/LINK] [r/REMARK] [t/TAG]…​`<br> e.g., `edit 2 n/James Lee e/jameslee@example.com`
-**Find**            | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
-**Find Company**            | `findcom KEYWORD [MORE_KEYWORDS]`<br> e.g., `find Google; Amazon`
+**Find**            | `find KEYWORD [;MORE_KEYWORDS]`<br> e.g., `find James; Jake`
+**Find Company**            | `findcom KEYWORD [;MORE_KEYWORDS]`<br> e.g., `find Google; Amazon`
 **Sort Company**            | `sortcom`
 **List**            | `list`
 **Deleted**         | `deleted`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -242,7 +242,7 @@ Format: `clear`
 
 Finds contacts whose names contain any of the given keywords.
 
-Format: `find KEYWORD [;MORE_KEYWORDS]`
+Format: `find KEYWORD [;MORE_KEYWORDS]…`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords matter. e.g. `Hans Bo` will not match `Bo Hans`
@@ -261,7 +261,7 @@ Examples:
 Finds all contacts whose company name matches any of the given keywords.
 
 Format:
-`findcom KEYWORD [; KEYWORD]…​`
+`findcom KEYWORD [;MORE_KEYWORDS]…​`
 
 * The search is **case-insensitive**.
   e.g. `google`, `Google`, `GOOGLE` are treated the same.
@@ -470,7 +470,7 @@ Action              | Format, Examples
 **Delete**          | `delete INDEX`<br> e.g., `delete 3`
 **Edit**            | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [c/COMPANY] [l/LINK] [r/REMARK] [t/TAG]…​`<br> e.g., `edit 2 n/James Lee e/jameslee@example.com`
 **Find**            | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
-**Find Company**            | `findcom COMPANY [; MORE_COMPANY]`<br> e.g., `find Google; Amazon`
+**Find Company**            | `findcom KEYWORD [MORE_KEYWORDS]`<br> e.g., `find Google; Amazon`
 **Sort Company**            | `sortcom`
 **List**            | `list`
 **Deleted**         | `deleted`

--- a/docs/diagrams/company/SortComActivityDiagram.puml
+++ b/docs/diagrams/company/SortComActivityDiagram.puml
@@ -5,15 +5,15 @@ start
 
 :User executes `sortcom`;
 
-if () then ([list is empty])
-    :Show message that there are no contacts to sort;
+if () then ([active contact list is empty?])
+    :Show message that there are no active contacts to sort;
     stop
 else ([else])
 endif
 
-:Sort currently displayed contacts by company name;
-:Update displayed contact list;
+:Display the sorted active contact list by company name;
 :Show success message;
 
 stop
 @enduml
+

--- a/docs/diagrams/company/SortComSequenceDiagram.puml
+++ b/docs/diagrams/company/SortComSequenceDiagram.puml
@@ -33,7 +33,7 @@ deactivate ABParser
 Logic -> Command : execute(m)
 activate Command
 
-Command -> Model : sort displayed contacts by company
+Command -> Model : sort active contacts by company
 activate Model
 Model --> Command
 deactivate Model

--- a/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
@@ -19,7 +19,7 @@ public class FindComCommand extends Command {
     public static final String COMMAND_WORD = "findcom";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts whose company matches "
-            + "the specified company name (case-insensitive).\n"
+            + "the specified company name (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: COMPANY [;MORE_COMPANIES]...\n"
             + "Example: " + COMMAND_WORD + " Google; Shopee; DBS";
 

--- a/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
@@ -20,8 +20,8 @@ public class FindComCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts whose company matches "
             + "the specified company name (case-insensitive).\n"
-            + "Parameters: COMPANY\n"
-            + "Example: " + COMMAND_WORD + " Google";
+            + "Parameters: COMPANY [;MORE_COMPANIES]...\n"
+            + "Example: " + COMMAND_WORD + " Google; Shopee; DBS";
 
     private static final Logger logger = LogsCenter.getLogger(FindComCommand.class);
 

--- a/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/FindComCommand.java
@@ -20,7 +20,7 @@ public class FindComCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts whose company matches "
             + "the specified company name (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: COMPANY [;MORE_COMPANIES]...\n"
+            + "Parameters: KEYWORD [;MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " Google; Shopee; DBS";
 
     private static final Logger logger = LogsCenter.getLogger(FindComCommand.class);

--- a/src/main/java/seedu/clinkedin/logic/commands/SortComCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/SortComCommand.java
@@ -9,15 +9,15 @@ import seedu.clinkedin.commons.util.ToStringBuilder;
 import seedu.clinkedin.model.Model;
 
 /**
- * Sorts the currently displayed contact list alphabetically by company name, case-insensitively.
- * If no contacts are currently displayed, returns a message indicating that there is nothing to sort.
+ * Sorts the active contact list alphabetically by company name, case-insensitively.
+ * If no contacts are active, returns a message indicating that there is nothing to sort.
  */
 public class SortComCommand extends Command {
 
     public static final String COMMAND_WORD = "sortcom";
-    public static final String MESSAGE_EMPTY = "No contacts to be sorted by company name.";
-    public static final String MESSAGE_SUCCESS = "Contacts sorted by company name.";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all displayed contacts by company name "
+    public static final String MESSAGE_EMPTY = "No active contacts to be sorted by company name.";
+    public static final String MESSAGE_SUCCESS = "Active contacts sorted by company name.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all active contacts by company name "
             + "alphabetically (case-insensitive).\n"
             + "Example: " + COMMAND_WORD;
 
@@ -28,10 +28,10 @@ public class SortComCommand extends Command {
         requireNonNull(model);
 
         int displayedCount = model.getFilteredPersonList().size();
-        logger.info("Executing sortcom on " + displayedCount + " displayed contact(s).");
+        logger.info("Executing sortcom on " + displayedCount + " active contact(s).");
 
         if (displayedCount == 0) {
-            logger.info("sortcom finished without sorting because there were no displayed contacts.");
+            logger.info("sortcom finished without sorting because there were no active contacts.");
             return new CommandResult(MESSAGE_EMPTY);
         }
 

--- a/src/main/java/seedu/clinkedin/logic/commands/SortComCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/SortComCommand.java
@@ -15,8 +15,8 @@ import seedu.clinkedin.model.Model;
 public class SortComCommand extends Command {
 
     public static final String COMMAND_WORD = "sortcom";
-    public static final String MESSAGE_EMPTY = "No active contacts to be sorted by company name.";
-    public static final String MESSAGE_SUCCESS = "Active contacts sorted by company name.";
+    public static final String MESSAGE_EMPTY = "No contacts to be sorted by company name.";
+    public static final String MESSAGE_SUCCESS = "Contacts sorted by company name.";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all active contacts by company name "
             + "alphabetically (case-insensitive).\n"
             + "Example: " + COMMAND_WORD;

--- a/src/main/java/seedu/clinkedin/logic/parser/FindComCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/FindComCommandParser.java
@@ -38,15 +38,17 @@ public class FindComCommandParser implements Parser<FindComCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
         }
 
-        List<String> companyKeywords = Arrays.stream(trimmedArgs.split(";"))
-                .map(String::trim)
-                .filter(keyword -> !keyword.isEmpty())
-                .toList();
-
-        if (companyKeywords.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
+        String[] companyKeywordsArray = trimmedArgs.split(";", -1);
+        for (String keyword : companyKeywordsArray) {
+            if (keyword.trim().isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
+            }
         }
+
+        List<String> companyKeywords = Arrays.stream(companyKeywordsArray)
+                .map(String::trim)
+                .toList();
 
         logger.info("Parsed findcom keywords: " + companyKeywords);
         return new FindComCommand(new CompanyContainsKeywordsPredicate(companyKeywords));

--- a/src/main/java/seedu/clinkedin/logic/parser/FindComCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/FindComCommandParser.java
@@ -38,7 +38,7 @@ public class FindComCommandParser implements Parser<FindComCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
         }
 
-        String[] companyKeywordsArray = trimmedArgs.split(";", -1);
+        String[] companyKeywordsArray = trimmedArgs.split(";");
         for (String keyword : companyKeywordsArray) {
             if (keyword.trim().isEmpty()) {
                 throw new ParseException(

--- a/src/main/java/seedu/clinkedin/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/FindCommandParser.java
@@ -25,7 +25,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split(";");
+        String[] nameKeywords = trimmedArgs.split(";", -1);
         for (String keywords : nameKeywords) {
             if (keywords.trim().isEmpty()) {
                 throw new ParseException(

--- a/src/main/java/seedu/clinkedin/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/FindCommandParser.java
@@ -25,7 +25,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split(";", -1);
+        String[] nameKeywords = trimmedArgs.split(";");
         for (String keywords : nameKeywords) {
             if (keywords.trim().isEmpty()) {
                 throw new ParseException(

--- a/src/main/java/seedu/clinkedin/model/ModelManager.java
+++ b/src/main/java/seedu/clinkedin/model/ModelManager.java
@@ -194,19 +194,22 @@ public class ModelManager implements Model {
     }
 
     //@@author savagexr3
-    //=========== Filtered Person List Sorting =============================================================
+    //=========== Active Person List Sorting =============================================================
 
     /**
-     * Sorts the currently displayed (filtered) list of {@code Person} by company name (case-insensitive).
+     * Sorts the active list of {@code Person}
+     * by company name in a case-insensitive manner.
      *
      * <p>
-     * Sorting is applied only to the filtered view (i.e., {@code sortedPersons}),
+     * Sorting is applied only to the active view (i.e., {@code sortedPersons}),
      * and does not modify the underlying {@code CLinkedin} person list.
      * </p>
      *
      * <p>
-     * Persons without a company are treated as having an empty string (""),
-     * and will appear before persons with non-empty company names.
+     * Persons without a company are treated as having an empty string ("") and
+     * will appear before persons with non-empty company names. If multiple persons
+     * have the same company value, their names are used as a secondary sorting key
+     * to keep the ordering deterministic.
      * </p>
      */
     @Override
@@ -214,15 +217,21 @@ public class ModelManager implements Model {
         sortedPersons.setComparator((p1, p2) -> {
             String company1 = p1.getCompany() != null ? p1.getCompany().value : "";
             String company2 = p2.getCompany() != null ? p2.getCompany().value : "";
-            return company1.compareToIgnoreCase(company2);
+
+            int companyCompare = company1.compareToIgnoreCase(company2);
+            if (companyCompare != 0) {
+                return companyCompare;
+            }
+
+            return p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName);
         });
     }
 
     /**
-     * Resets any sorting applied to the filtered person list.
+     * Resets any sorting applied to the active person list.
      *
      * <p>
-     * After calling this method, the filtered list will revert to its original
+     * After calling this method, the active list will revert to its original
      * order as defined by the underlying {@code CLinkedin} data.
      * </p>
      */

--- a/src/main/java/seedu/clinkedin/model/ModelManager.java
+++ b/src/main/java/seedu/clinkedin/model/ModelManager.java
@@ -201,7 +201,7 @@ public class ModelManager implements Model {
      * by company name in a case-insensitive manner.
      *
      * <p>
-     * Sorting is applied only to the active view (i.e., {@code sortedPersons}),
+     * Sorting is applied only to the filtered view (i.e., {@code sortedPersons}),
      * and does not modify the underlying {@code CLinkedin} person list.
      * </p>
      *

--- a/src/test/java/seedu/clinkedin/logic/parser/FindComCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/FindComCommandParserTest.java
@@ -69,12 +69,35 @@ public class FindComCommandParserTest {
     }
 
     @Test
-    public void parse_oneValidOneEmptyKeyword_ignoresEmptyAndSucceeds() {
-        // Heuristic for multiple inputs: empty optional components after splitting are removed,
-        // while remaining valid components should still produce a positive test case.
-        FindComCommand expectedFindComCommand =
-                new FindComCommand(new CompanyContainsKeywordsPredicate(Arrays.asList("Google")));
+    public void parse_oneValidOneEmptyKeyword_throwsParseException() {
+        // Heuristic for multiple inputs: only one invalid input
+        // (an empty keyword segment after trimming) should appear in one negative test case.
+        assertParseFailure(parser, "Google; ;",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
 
-        assertParseSuccess(parser, "Google;   ;", expectedFindComCommand);
+    }
+
+    @Test
+    public void parse_validKeywordWithTrailingSeparator_throwsParseException() {
+        // EP: one valid keyword followed by one empty keyword segment
+        assertParseFailure(parser,
+                "Google;",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_leadingSeparatorBeforeValidKeyword_throwsParseException() {
+        // EP: one empty keyword segment followed by one valid keyword
+        assertParseFailure(parser,
+                ";Google",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_onlySeparator_throwsParseException() {
+        // EP: semicolon input where all keyword segments are empty
+        assertParseFailure(parser,
+                ";",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/clinkedin/logic/parser/FindComCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/FindComCommandParserTest.java
@@ -78,26 +78,10 @@ public class FindComCommandParserTest {
     }
 
     @Test
-    public void parse_validKeywordWithTrailingSeparator_throwsParseException() {
-        // EP: one valid keyword followed by one empty keyword segment
-        assertParseFailure(parser,
-                "Google;",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
-    }
-
-    @Test
     public void parse_leadingSeparatorBeforeValidKeyword_throwsParseException() {
         // EP: one empty keyword segment followed by one valid keyword
         assertParseFailure(parser,
                 ";Google",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
-    }
-
-    @Test
-    public void parse_onlySeparator_throwsParseException() {
-        // EP: semicolon input where all keyword segments are empty
-        assertParseFailure(parser,
-                ";",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindComCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/clinkedin/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/FindCommandParserTest.java
@@ -45,4 +45,28 @@ public class FindCommandParserTest {
                 "irfan;   ;",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_validKeywordWithTrailingSeparator_throwsParseException() {
+        // EP: one valid keyword followed by one empty keyword segment
+        assertParseFailure(parser,
+                "irfan;",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_leadingSeparatorBeforeValidKeyword_throwsParseException() {
+        // EP: one empty keyword segment followed by one valid keyword
+        assertParseFailure(parser,
+                ";irfan",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_onlySeparator_throwsParseException() {
+        // EP: semicolon input where all keyword segments are empty
+        assertParseFailure(parser,
+                ";",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/clinkedin/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/FindCommandParserTest.java
@@ -47,26 +47,10 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validKeywordWithTrailingSeparator_throwsParseException() {
-        // EP: one valid keyword followed by one empty keyword segment
-        assertParseFailure(parser,
-                "irfan;",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-    }
-
-    @Test
     public void parse_leadingSeparatorBeforeValidKeyword_throwsParseException() {
         // EP: one empty keyword segment followed by one valid keyword
         assertParseFailure(parser,
                 ";irfan",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-    }
-
-    @Test
-    public void parse_onlySeparator_throwsParseException() {
-        // EP: semicolon input where all keyword segments are empty
-        assertParseFailure(parser,
-                ";",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/clinkedin/model/ModelManagerTest.java
+++ b/src/test/java/seedu/clinkedin/model/ModelManagerTest.java
@@ -309,6 +309,67 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void sortFilteredPersonListByCompany_noCompany_sortsByName() {
+        // EP: persons without a company are treated as having the same empty company value
+        // and are further sorted by name
+        Person ben = new PersonBuilder()
+                .withName("Ben Tan")
+                .withPhone("93456789")
+                .withEmail("ben@example.com")
+                .withAddress("Ben Street")
+                .build();
+
+        Person alex = new PersonBuilder()
+                .withName("Alex Tan")
+                .withPhone("91234567")
+                .withEmail("alex@example.com")
+                .withAddress("Alex Street")
+                .build();
+
+        CLinkedin cLinkedin = new AddressBookBuilder()
+                .withPerson(ben)
+                .withPerson(alex)
+                .build();
+        ModelManager sortedModelManager = new ModelManager(cLinkedin, new UserPrefs());
+
+        sortedModelManager.sortFilteredPersonListByCompany();
+
+        assertEquals(alex, sortedModelManager.getFilteredPersonList().get(0));
+        assertEquals(ben, sortedModelManager.getFilteredPersonList().get(1));
+    }
+
+    @Test
+    public void sortFilteredPersonListByCompany_sameCompany_sortsByName() {
+        // EP: persons with the same company value are sorted by name as a secondary key
+        Person beta = new PersonBuilder()
+                .withName("Beta Tan")
+                .withPhone("92345678")
+                .withEmail("beta@example.com")
+                .withAddress("Beta Street")
+                .withCompany("Google")
+                .build();
+
+        Person alpha = new PersonBuilder()
+                .withName("Alpha Tan")
+                .withPhone("91234567")
+                .withEmail("alpha@example.com")
+                .withAddress("Alpha Street")
+                .withCompany("Google")
+                .build();
+
+        CLinkedin cLinkedin = new AddressBookBuilder()
+                .withPerson(beta)
+                .withPerson(alpha)
+                .build();
+        ModelManager sortedModelManager = new ModelManager(cLinkedin, new UserPrefs());
+
+        sortedModelManager.sortFilteredPersonListByCompany();
+
+        assertEquals(alpha, sortedModelManager.getFilteredPersonList().get(0));
+        assertEquals(beta, sortedModelManager.getFilteredPersonList().get(1));
+    }
+
+    @Test
     public void equals_differentSortedPersons_returnsFalse() {
         // EP: sorted view differs between two otherwise equal model managers
         CLinkedin cLinkedin = new AddressBookBuilder().withPerson(BENSON).withPerson(ALICE).build();


### PR DESCRIPTION
**PR Description:**
This PR improves consistency between documentation and command behavior for `sortcom`, `find`, and `findcom`.

Changes made:

* Added a Planned Enhancement for supporting `sortcom` on the deleted list in future versions.
* Clarified documentation wording by replacing “currently displayed contact list” with “active contact list” for `sortcom`.
* Aligned `find` and `findcom` parsing behavior so malformed semicolon-separated inputs are consistently rejected, including cases like:

  * `[xxx];`
  * `;;;;;;`
  * `;[xxx]`
  * `;`
* Fixed handling of empty keywords in `find` and `findcom`, so commands like `find ;` and `findcom ;` now return an error instead of succeeding.
* Fixed inconsistent index changes in `sortcom` for contacts without a company by adding a deterministic tie-breaker using name.

Issues closed:

* closes #237
* closes #219
* closes #231
* closes #221
