### PR TITLE
Change color format to be more specific

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -387,7 +387,7 @@ Adds a color to a tag.
 Format: `tag color TAG_NAME COLOR`
 
 * Adds a valid color to the specified `TAG_NAME`.
-* A valid color is any case-insensitive plain name, or hexadecimal value.
+* A valid color is any case-insensitive [standard JavaFX named color](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/paint/Color.html), or hexadecimal value.
 * If the tag does not exist, an error message will be shown.
 * If the color is invalid, an error message will be shown.
 

--- a/src/main/java/seedu/clinkedin/model/tag/Tag.java
+++ b/src/main/java/seedu/clinkedin/model/tag/Tag.java
@@ -29,7 +29,9 @@ public class Tag {
 
     public static final String MESSAGE_INVALID_COLOR_NAME =
             "Invalid color name.\n"
-                    + "Valid formats are in case-insensitive plain name, or hexadecimal and it's shorthand values.\n"
+                    + "Only colors defined in JavaFX `Color.web()` are accepted\n"
+                    + "Valid formats are in case-insensitive standard named colors (e.g. red, blue)\n"
+                    + "Or hexadecimal and it's shorthand values.\n"
                     + "Example: #123, #ff6688, orange";
 
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";


### PR DESCRIPTION
Fixes #214 

1. Changed error message to be more specific about JavaFX's color
```
Invalid color name.
Only colors defined in JavaFX `Color.web()` are accepted
Valid formats are in case-insensitive standard named colors (e.g. red, blue)
Or hexadecimal and it's shorthand values.
Example: #123, #ff6688, orange
```

2. Update UG to also link to JavaFX's color page.

Please remember to refer to the original issue and see if this is a ideal fix, although rxlee04 has seen all the issues I think assigning every PR for her to review is too much, thanks.