### PR TITLE
Show empty list when tag is not found in tag show command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -403,7 +403,7 @@ Format: `tag show TAG_NAME`
 
 * The list will be filtered to show contacts that have `TAG_NAME`.
 * Filters based on a single tag only.
-* If the tag does not exist, an error message will be shown and the active list will be empty.
+* If the tag does not exist, the empty active list with an error message will be shown.
 
 Examples:
 * `tag show friends`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -403,7 +403,7 @@ Format: `tag show TAG_NAME`
 
 * The list will be filtered to show contacts that have `TAG_NAME`.
 * Filters based on a single tag only.
-* If the tag does not exist, an error message will be shown.
+* If the tag does not exist, an error message will be shown and the active list will be empty.
 
 Examples:
 * `tag show friends`

--- a/src/main/java/seedu/clinkedin/logic/commands/tag/TagShowCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/tag/TagShowCommand.java
@@ -1,6 +1,7 @@
 package seedu.clinkedin.logic.commands.tag;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.clinkedin.model.Model.PREDICATE_SHOW_EMPTY;
 
 import seedu.clinkedin.logic.commands.CommandResult;
 import seedu.clinkedin.logic.commands.exceptions.CommandException;
@@ -33,6 +34,7 @@ public class TagShowCommand extends TagCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         if (!model.hasTag(tag)) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_EMPTY);
             throw new CommandException(MESSAGE_TAG_NOT_FOUND + tag.toString());
         }
 

--- a/src/main/java/seedu/clinkedin/model/Model.java
+++ b/src/main/java/seedu/clinkedin/model/Model.java
@@ -20,6 +20,8 @@ public interface Model {
      */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
+    Predicate<Person> PREDICATE_SHOW_EMPTY = unused -> false;
+
     /**
      * {@code Predicate} that always evaluates to true for deleted person records.
      */


### PR DESCRIPTION
Fixes #240 
Fixes #252 

1. Added a predicate that always returns an empty list.
2. If a tag is not found in `tag show`, an empty list will be shown to the user.
3. Updated the UG to say the same thing.