### PR TITLE
Remove bottom section for object names in Seq Diagrams

### DIFF
--- a/docs/diagrams/RestoreSequenceDiagram.puml
+++ b/docs/diagrams/RestoreSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `restore` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/company/FindComSequenceDiagram.puml
+++ b/docs/diagrams/company/FindComSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `findcom` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/company/SortComSequenceDiagram.puml
+++ b/docs/diagrams/company/SortComSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `sortcom` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagAssignSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagAssignSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag assign` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagColorSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagColorSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag color` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagCreateSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagCreateSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag create` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagDeleteSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagDeleteSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag delete` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagRenameSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagRenameSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag rename` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagShowSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagShowSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag show` command
+hide footbox
 
 actor User
 

--- a/docs/diagrams/tag/TagUnassignSequenceDiagram.puml
+++ b/docs/diagrams/tag/TagUnassignSequenceDiagram.puml
@@ -1,5 +1,6 @@
 @startuml
 title Sequence Diagram for the `tag unassign` command
+hide footbox
 
 actor User
 


### PR DESCRIPTION
**Summary**
---
**Fixed**
- Removed object/class name from bottom of all sequence diagrams using hide footbox [#227](https://github.com/AY2526S2-CS2103-T11-1/tp/issues/227)