### PR TITLE
Fix bugs with tag assign and unassign command

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/tag/TagUnassignCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/tag/TagUnassignCommand.java
@@ -98,7 +98,7 @@ public class TagUnassignCommand extends TagCommand {
         List<Person> snapshot = new ArrayList<>(lastShownList);
         for (Index index : indexes) {
             Person personToEdit = snapshot.get(index.getZeroBased());
-            Person currentPerson = model.getFilteredPersonList().get(index.getZeroBased());
+            Person currentPerson = snapshot.get(index.getZeroBased());
             Person editedPerson = new Person(
                     currentPerson.getName(),
                     currentPerson.getPhone(),

--- a/src/main/java/seedu/clinkedin/logic/parser/tag/TagAssignCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/tag/TagAssignCommandParser.java
@@ -40,6 +40,11 @@ public class TagAssignCommandParser implements Parser<TagAssignCommand> {
         // remove all spaces to handle "1 , 2 , 3" and "1, 2, 3"
         indexPart = indexPart.replaceAll("\\s+", "");
 
+        if (indexPart.matches(".*[a-zA-Z].*")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagAssignCommand.MESSAGE_USAGE));
+        }
+
         if (indexPart.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagAssignCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/clinkedin/logic/parser/tag/TagUnassignCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/tag/TagUnassignCommandParser.java
@@ -40,6 +40,11 @@ public class TagUnassignCommandParser implements Parser<TagUnassignCommand> {
         // remove all spaces to handle "1 , 2 , 3" and "1, 2, 3"
         indexPart = indexPart.replaceAll("\\s+", "");
 
+        if (indexPart.matches(".*[a-zA-Z].*")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagUnassignCommand.MESSAGE_USAGE));
+        }
+
         if (indexPart.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagUnassignCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/clinkedin/logic/parser/tag/TagAssignCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/tag/TagAssignCommandParserTest.java
@@ -86,4 +86,16 @@ public class TagAssignCommandParserTest {
         assertParseFailure(parser, "1,2, friends",
                 "Indexes should not end with a comma.");
     }
+
+    @Test
+    public void parse_multipleTagNames_throwsParseException() {
+        assertParseFailure(parser, "1 Enemy friend",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagAssignCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_alphanumericInIndexPart_throwsParseException() {
+        assertParseFailure(parser, "1abc friend",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagAssignCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/clinkedin/logic/parser/tag/TagUnassignCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/tag/TagUnassignCommandParserTest.java
@@ -87,4 +87,16 @@ public class TagUnassignCommandParserTest {
         assertParseFailure(parser, "1,2, friends",
                 "Indexes should not end with a comma.");
     }
+
+    @Test
+    public void parse_multipleTagNames_throwsParseException() {
+        assertParseFailure(parser, "1 Enemy friend",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagUnassignCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_alphanumericInIndexPart_throwsParseException() {
+        assertParseFailure(parser, "1abc friend",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagUnassignCommand.MESSAGE_USAGE));
+    }
 }


### PR DESCRIPTION
Closes #268 
- Fixed runtime error when unassigning tags from flitered list

Closes #238
- Correctly shows the error message for invalid command when the command parameters are not met