### PR TITLE
Add repeated name validation in find

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/Messages.java
+++ b/src/main/java/seedu/clinkedin/logic/Messages.java
@@ -21,6 +21,8 @@ public class Messages {
     public static final String MESSAGE_COMPANIES_LISTED_OVERVIEW = "%d contacts listed working at \"%s\".";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_FIND_REPEATED_NAMES =
+            "Your search contains duplicate keywords. Remove repeated terms and try again.";
     public static final String MESSAGE_INVALID_DELETED_PERSON_RECORD_DISPLAYED_INDEX =
             "The deleted person record index provided is invalid";
     public static final String MESSAGE_TAG_SHOW_SINGLE_TAG_ONLY =

--- a/src/main/java/seedu/clinkedin/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/FindCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.clinkedin.logic.parser;
 
+import static seedu.clinkedin.logic.Messages.MESSAGE_FIND_REPEATED_NAMES;
 import static seedu.clinkedin.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
@@ -34,6 +35,11 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         nameKeywords = Arrays.stream(nameKeywords).map(x -> x.trim()).toArray(String[]::new);
+
+        long distinct = Arrays.stream(nameKeywords).map(String::toLowerCase).distinct().count();
+        if (distinct != nameKeywords.length) {
+            throw new ParseException(MESSAGE_FIND_REPEATED_NAMES);
+        }
 
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/test/java/seedu/clinkedin/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/FindCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.clinkedin.logic.parser;
 
+import static seedu.clinkedin.logic.Messages.MESSAGE_FIND_REPEATED_NAMES;
 import static seedu.clinkedin.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.clinkedin.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.clinkedin.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -52,5 +53,13 @@ public class FindCommandParserTest {
         assertParseFailure(parser,
                 ";irfan",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_repeatedTwoNames_throwsParseException() {
+        assertParseFailure(parser, "AlIcE;aLiCE", MESSAGE_FIND_REPEATED_NAMES);
+
+        // multiple whitespaces between keywords
+        assertParseFailure(parser, " \n Alice; \n \t Alice  \t", MESSAGE_FIND_REPEATED_NAMES);
     }
 }


### PR DESCRIPTION
Fixes #257 

now when user enter repeated keywords in find command such as `find j; j; j;` or `find joHn; jOHN;`

an error will pop